### PR TITLE
notebook to copy dataset and create manifest

### DIFF
--- a/CopyDataset.ipynb
+++ b/CopyDataset.ipynb
@@ -1,0 +1,294 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1a6dc7c4-cc8b-4533-9e45-993396464702",
+   "metadata": {},
+   "source": [
+    "# Transfer (copy) datasets and create manifest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17a1d8fc-b738-42a5-99a6-8ddebbcfa756",
+   "metadata": {},
+   "source": [
+    "This notebook shows how to copy a dataset (folder) from one Globus guest collection to another guest collection and create a manifest of the files copied the manifest is then uploaded to the destination collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "746f3109-bf7e-4a20-83fa-b86785750ddf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import requests\n",
+    "from os.path import relpath\n",
+    "import globus_sdk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a25be72-e7a6-427b-aa37-de46d2aa0b13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build link to webapp pages for transfer status and results\n",
+    "# Show how to find things through the UI\n",
+    "# Same information, different interfaces"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b70a446-132d-437e-97bb-044ed1a8ddae",
+   "metadata": {},
+   "source": [
+    "### Log in to Globus and get access tokens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7fdd774-d0f5-4b36-87da-a49b971bb22c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Adapted from the Globus Transfer API Exercises example notebook\n",
+    "# https://github.com/globus/globus-jupyter-notebooks/blob/master/Transfer_API_Exercises.ipynb\n",
+    "\n",
+    "CLIENT_ID = \"3b1925c0-a87b-452b-a492-2c9921d3bd14\"\n",
+    "native_auth_client = globus_sdk.NativeAppAuthClient(CLIENT_ID)\n",
+    "\n",
+    "cheapandfair_collection = \"7352d991-b0a0-49a2-830c-e8fe8c968ca2\"  # collection \"Cheap and FAIR Tutorial Datasets\"\n",
+    "your_srdr_collection = \"gggggggg-hhhh-iiii-jjjj-kkkkkkkkkkkk\"  # collection \"SRDR Tutorial Collection {n}\"\n",
+    "\n",
+    "# As in the Platform_Introduction_Native_App_Auth notebook, do the Native App Grant Flow\n",
+    "SCOPES = [globus_sdk.scopes.TransferScopes.all,\n",
+    "         f'https://auth.globus.org/scopes/{your_srdr_collection}/https']\n",
+    "\n",
+    "# May need to be set to \"login\" below, if you need to authorize a specific identity for your collection\n",
+    "PROMPT=None\n",
+    "\n",
+    "native_auth_client = globus_sdk.NativeAppAuthClient(CLIENT_ID)\n",
+    "native_auth_client.oauth2_start_flow(requested_scopes=SCOPES)\n",
+    "print(f\"Login Here:\\n\\n{native_auth_client.oauth2_get_authorize_url(prompt=PROMPT)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b0bf623-95b4-4d0a-be15-f53ce6815774",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auth_code = \"your auth code here\"\n",
+    "tokens = native_auth_client.oauth2_exchange_code_for_tokens(auth_code).by_resource_server"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e3e2893-b720-44b1-bf27-0765c3789a17",
+   "metadata": {},
+   "source": [
+    "### Get the Tokens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f889127-f8ae-491a-b04b-25ebbf78a84b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transfer_access_token = tokens['transfer.api.globus.org']['access_token']\n",
+    "transfer_authorizer = globus_sdk.AccessTokenAuthorizer(transfer_access_token)\n",
+    "tc = globus_sdk.TransferClient(authorizer=transfer_authorizer)\n",
+    "https_token = tokens[your_srdr_collection]['access_token']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1c5f662-fe47-4f47-a0e3-0480cf273ba4",
+   "metadata": {},
+   "source": [
+    "### Get the base URL of the SRDR collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc78c00e-aea6-43e7-89c8-b5c5b6680d65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "srdr_coll_info = tc.get_endpoint(your_srdr_collection)\n",
+    "srdr_base_url = srdr_coll_info['https_server']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be6da731-5d0d-4aad-8d4b-daf52e4df677",
+   "metadata": {},
+   "source": [
+    "### Transfer (copy) the dataset to the SRDR collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34893172-d4f2-4806-80d3-5716f08d7ac8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_id = cheapandfair_collection\n",
+    "dest_id = your_srdr_collection\n",
+    "\n",
+    "source_path = '/public/datasets/cmb/'\n",
+    "dest_path = '/datasets/cmb/'\n",
+    "\n",
+    "# This does not exactly match -a, for example it cannot preserve permissions or ownership\n",
+    "tdata = globus_sdk.TransferData(tc, source_id, dest_id,\n",
+    "                                preserve_timestamp=True)\n",
+    "\n",
+    "tdata.add_item(source_path, dest_path, recursive=True, checksum_algorithm='sha256')\n",
+    "\n",
+    "submit_result = tc.submit_transfer(tdata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07b2cfac-72e7-42b4-bb37-644cc50d4f18",
+   "metadata": {},
+   "source": [
+    "Wait until this transfer completes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cc450a8-24ed-4739-a82f-60ed55b54be0",
+   "metadata": {},
+   "source": [
+    "### Build the Manifest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "deaf7a85-131d-4ff6-9b6d-ed47bd8d0a23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manifest = []\n",
+    "next_marker=None\n",
+    "while True:\n",
+    "    transfers = tc.get(f\"/task/{submit_result['task_id']}/successful_transfers\", query_params=dict(marker=next_marker))\n",
+    "    next_marker = transfers['next_marker']\n",
+    "    for t in transfers['DATA']:\n",
+    "        file_entry = {\n",
+    "            'filename': relpath(t['destination_path'], dest_path),\n",
+    "            'length': t['size'],\n",
+    "            'url': srdr_base_url + t['destination_path'],\n",
+    "            t['checksum_algorithm'].lower(): t['checksum']\n",
+    "        }\n",
+    "        manifest.append(file_entry)\n",
+    "    if next_marker is None:\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f8c1ecd-e7ea-48b5-837c-65ccc3008a01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for f in manifest:\n",
+    "    for k in f.keys():\n",
+    "        print(k + ': ' + str(f[k]))\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8c56cb5-2126-4263-8ef7-17ee8148e7e8",
+   "metadata": {},
+   "source": [
+    "## upload the manifest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da20d92d-b333-498e-9345-94bbf51d24d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "put_url = f'{srdr_base_url}/{dest_path}manifest.json'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a3f1575-f720-49dc-8687-74f2aa19251a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "headers = {'Authorization':'Bearer '+ https_token}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b88dc5a8-3605-4cb9-81dc-317fa4ae7d08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = requests.put(put_url, headers=headers, json=manifest, allow_redirects=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea0e709b-031f-4b0c-af2e-860ac719d1aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not resp.text:\n",
+    "    c = str(resp.status_code)\n",
+    "    print(f'PUT to {put_url} status {c}')\n",
+    "    stat = requests.head(put_url,headers=headers, allow_redirects=False)\n",
+    "    print('File info (HEAD)')\n",
+    "    for h in 'Content-Length', 'Content-Type':\n",
+    "        v = stat.headers[h]\n",
+    "        print(f'{h}: {v}')\n",
+    "else:\n",
+    "    print(f'FAILED PUT to {put_url}')\n",
+    "    print(f'Check permissions on collection at https://app.globus.org/file-manager/collections/{your_srdr_collection}/sharing')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook shows how to use Globus to copy a dataset from one guest collection to another. It also generates the manifest and uploads it to the destination. 

We can save the manifest locally to help build the dataset landing pages.

Needs more narrative text and maybe some diagrams, unless those end up in the presentation.